### PR TITLE
add explicit types to two lines in d3-axis/index.d.ts

### DIFF
--- a/d3-axis/index.d.ts
+++ b/d3-axis/index.d.ts
@@ -4,7 +4,7 @@ export interface Axis {
    *
    * @link https://github.com/d3/d3-axis#_axis
    */
-  (selectionOrTransition:any);
+  (selectionOrTransition:any): any;
 
   /** @link https://github.com/d3/d3-axis#axis_scale */
   scale():any;
@@ -16,7 +16,7 @@ export interface Axis {
    *
    * @link https://github.com/d3/d3-axis#axis_ticks
    */
-  ticks(...args):this;
+  ticks(...args: any[]):this;
 
   /**
    * pass to scale.ticks(count:number)


### PR DESCRIPTION
I was using this for a personal project and the typescript compiler was throwing any type implication errors on lines 7 and 19. the args[] on ticks needed an any[] type, and the call signature on line 7 needed an additional ": any" outside the parentheses in order to compile properly.